### PR TITLE
Feature form

### DIFF
--- a/src/modules/featureform/featureform-directive.js
+++ b/src/modules/featureform/featureform-directive.js
@@ -27,8 +27,8 @@ angular.module('anol.featureform')
      * @param {anol.layer.Feature} layer Layer of feature
      * @param {FormField[]} pointFields The form fields for points
      * @param {FormField[]} lineFields The form fields for lines
-     * @param {FormField[]} polygonFields TThe form fields for polygons
-     * @param {Object<string, string>} formValues The values for each form field
+     * @param {FormField[]} polygonFields The form fields for polygons
+     * @param {boolean} [highlightInvalid] show if fields are invalid
      *
      * @description
      * Creates a form to edit defined feature properties.
@@ -42,9 +42,10 @@ angular.module('anol.featureform')
                 scope: {
                     'feature': '=',
                     'layer': '=', // TODO: is this needed?
-                    'pointFields': '=',
-                    'lineFields': '=',
-                    'polygonFields': '='
+                    'pointFields': '=?',
+                    'lineFields': '=?',
+                    'polygonFields': '=?',
+                    'highlightInvalid': '=?'
                 },
                 template: function(tElement, tAttrs) {
                     if (tAttrs.templateUrl) {
@@ -118,6 +119,17 @@ angular.module('anol.featureform')
                      */
                     scope.getOptionLabel = function (option) {
                         return angular.isObject(option) ? option.label || option.value : option;
+                    };
+
+                    /**
+                     * @param {FormField} field
+                     * @return {boolean}
+                     */
+                    scope.isValid = function (field) {
+                        if (field.required) {
+                            return !!scope.properties[field.name];
+                        }
+                        return true;
                     };
 
                     scope.$watch('feature', featureChangeHandler);

--- a/src/modules/featureform/featureform-directive.js
+++ b/src/modules/featureform/featureform-directive.js
@@ -45,7 +45,7 @@ angular.module('anol.featureform')
                     'pointFields': '=?',
                     'lineFields': '=?',
                     'polygonFields': '=?',
-                    'highlightInvalid': '=?'
+                    'highlightInvalid': '<?'
                 },
                 template: function(tElement, tAttrs) {
                     if (tAttrs.templateUrl) {
@@ -127,7 +127,15 @@ angular.module('anol.featureform')
                      */
                     scope.isValid = function (field) {
                         if (field.required) {
-                            return !!scope.properties[field.name];
+                            const value = scope.properties[field.name];
+                            switch (field.type) {
+                            case 'int':
+                            case 'float':
+                                return angular.isNumber(value);
+                            case 'text':
+                            case 'select':
+                                return angular.isString(value) && value !== '';
+                            }
                         }
                         return true;
                     };

--- a/src/modules/featureform/featureform-directive.js
+++ b/src/modules/featureform/featureform-directive.js
@@ -2,7 +2,7 @@ import './module.js';
 
 /**
  * @typedef {object} SelectOption
- * @property {string} label
+ * @property {string} [label]
  * @property {string} value
  */
 
@@ -10,8 +10,8 @@ import './module.js';
  * @typedef {object} FormField
  * @property {string} name the name of the property
  * @property {string} type the type of the input
- * @property {string} label the label of the input
- * @property {string[]} select the available options if type=='select'
+ * @property {string} [label] the label of the input
+ * @property {Array<SelectOption|string>} select the available options if type=='select'
  * @property {boolean} [required]
  */
 
@@ -21,31 +21,26 @@ angular.module('anol.featureform')
      * @name anol.featureform.directive:anolFeatureForm
      *
      * @restrict A
-     * @requires pascalprecht.$translate
      *
      * @param {string} templateUrl Url to template to use instead of default one
      * @param {ol.Feature} feature Feature to show properties for
      * @param {anol.layer.Feature} layer Layer of feature
      * @param {FormField[]} formFields The options for each form field
      * @param {Object<string, string>} formValues The values for each form field
-     * @param {string} translationNamespace Namespace to use in translation table. Default "featureform".
      *
      * @description
      * Creates a form to edit defined feature properties.
      *
      */
-    .directive('anolFeatureForm', ['$templateRequest', '$compile', '$translate',
-        function($templateRequest, $compile, $translate) {
+    .directive('anolFeatureForm', ['$templateRequest', '$compile',
+        function($templateRequest, $compile) {
             return {
                 restrict: 'A',
                 require: '?^anolFeaturePopup',
                 scope: {
                     'feature': '=',
                     'layer': '=', // TODO: is this needed?
-                    'selects': '=', // TODO: is this needed?
-                    'formFields': '=',
-                    'formValues': '=',
-                    'translationNamespace': '@' // TODO: is this needed?
+                    'formFields': '='
                 },
                 template: function(tElement, tAttrs) {
                     if (tAttrs.templateUrl) {
@@ -61,76 +56,48 @@ angular.module('anol.featureform')
                             $compile(template)(scope);
                         });
                     }
-                    //
-                    // scope.$watch('formFields', function (formFields) {
-                    //     console.log(formFields)
-                    // });
-                //     scope.translationNamespace = angular.isDefined(scope.translationNamespace) ?
-                //         scope.translationNamespace : 'featureform';
-                //
-                //     scope.propertiesCollection = [];
-                //
-                //     var featureChangeHandler = function(feature) {
-                //         var propertiesCollection = [];
-                //         if(angular.isUndefined(scope.layer) || !angular.isObject(scope.layer.featureinfo)) {
-                //             scope.propertiesCollection = propertiesCollection;
-                //         } else {
-                //             var properties = propertiesFromFeature(feature, scope.layer.name, scope.layer.featureinfo.properties);
-                //             if(!angular.equals(properties, {})) {
-                //                 propertiesCollection.push(properties);
-                //             }
-                //             scope.propertiesCollection = propertiesCollection;
-                //         }
-                //         if(FeaturePopupController !== null && scope.propertiesCollection.length === 0) {
-                //             FeaturePopupController.close();
-                //         }
-                //     };
-                //
-                //     var selectsChangeHandler = function(selects) {
-                //         var propertiesCollection = [];
-                //         angular.forEach(selects, function(selectObj) {
-                //             var layer = selectObj.layer;
-                //             var features = selectObj.features;
-                //             if(!angular.isObject(layer.featureinfo) || features.length === 0) {
-                //                 return;
-                //             }
-                //             angular.forEach(features, function(feature) {
-                //                 var properties = propertiesFromFeature(feature, layer.name, layer.featureinfo.properties);
-                //                 if(!angular.equals(properties, {})) {
-                //                     propertiesCollection.push(properties);
-                //                 }
-                //             });
-                //         });
-                //         scope.propertiesCollection = propertiesCollection;
-                //         if(FeaturePopupController !== null && scope.propertiesCollection.length === 0) {
-                //             FeaturePopupController.close();
-                //         }
-                //     };
-                //
-                //     scope.$watch('feature', featureChangeHandler);
-                //     scope.$watchCollection('selects', selectsChangeHandler);
+
+                    scope.properties = {};
+
+                    /**
+                     * @param {ol.Feature} feature
+                     */
+                    var featureChangeHandler = function (feature) {
+                        if (feature) {
+                            scope.properties = feature.getProperties();
+                        }
+                    };
+
+                    /**
+                     * @param {FormField[]} formFields
+                     */
+                    var formFieldChangeHandler = function (formFields) {
+                        formFields.forEach(function (field) {
+                            scope.$watch('properties["' + field.name + '"]', function (value) {
+                                scope.feature.set(field.name, value);
+                            });
+                        });
+                    };
+
+                    /**
+                     * @param {SelectOption|string} option
+                     * @return {string}
+                     */
+                    scope.getOptionValue = function (option) {
+                        return angular.isObject(option) ? option.value : option;
+                    };
+
+                    /**
+                     * @param {SelectOption|string} option
+                     * @return {string}
+                     */
+                    scope.getOptionLabel = function (option) {
+                        return angular.isObject(option) ? option.label || option.value : option;
+                    };
+
+                    scope.$watch('feature', featureChangeHandler);
+
+                    scope.$watch('formFields', formFieldChangeHandler);
                 }
             };
         }]);
-
-    // .directive('urlOrText', [function() {
-    //     return {
-    //         restrict: 'E',
-    //         scope: {
-    //             url: '=value'
-    //         },
-    //         link: function(scope, element) {
-    //             var isUrl = function(s) {
-    //                 var regexp = /(http:\/\/|https:\/\/|www\.)/;
-    //                 return regexp.test(s);
-    //             };
-    //             scope.$watch('url', function(url) {
-    //                 var content = url;
-    //                 if(isUrl(url)) {
-    //                     content = $('<a href="' + url + '">' + url + '</a>');
-    //                 }
-    //                 element.html(content);
-    //             });
-    //         }
-    //     };
-    // }]);

--- a/src/modules/featureform/templates/featureform.html
+++ b/src/modules/featureform/templates/featureform.html
@@ -2,17 +2,31 @@
     <div ng-repeat="field in formFields"
          class="form-group"
          ng-class="{ 'has-error': highlightInvalid && !isValid(field) }"
+         ng-switch="field.type"
     >
         <label for="input-{{field.name}}">
             {{ field.label || field.name }}{{ field.required ? ' (*)' : ''}}
         </label>
-        <input ng-if="field.type !== 'select'"
+        <input ng-switch-when="text"
                id="input-{{field.name}}"
                class="form-control"
-               type="{{field.type}}"
+               type="text"
                ng-model="properties[field.name]"
         />
-        <select ng-if="field.type === 'select'"
+        <input ng-switch-when="int"
+               id="input-{{field.name}}"
+               class="form-control"
+               type="number"
+               ng-model="properties[field.name]"
+        />
+        <input ng-switch-when="float"
+               id="input-{{field.name}}"
+               class="form-control"
+               type="number"
+               step="any"
+               ng-model="properties[field.name]"
+        />
+        <select ng-switch-when="select"
                 id="input-{{field.name}}"
                 class="form-control"
                 ng-model="properties[field.name]"
@@ -26,6 +40,9 @@
                 {{ getOptionLabel(option) }}
             </option>
         </select>
+        <div ng-switch-default>
+            {{ 'anol.featureform.INPUT_NOT_SUPPORTED' | translate }}"{{ field.type }}"
+        </div>
         <small ng-if="highlightInvalid && !isValid(field)"
                class="help-block">
             {{ 'anol.featureform.IS_REQUIRED' | translate }}

--- a/src/modules/featureform/templates/featureform.html
+++ b/src/modules/featureform/templates/featureform.html
@@ -1,11 +1,35 @@
 <form class="container-fluid" style="padding-top: 2em">
-    <div ng-repeat="field in formFields" class="form-group">
-        <label for="input-{{field.name}}">{{ field.label || field.name }}</label>
-        <input ng-if="field.type !== 'select'" class="form-control" type="{{field.type}}" id="input-{{field.name}}" ng-model="properties[field.name]"/>
-        <select ng-if="field.type === 'select'" class="form-control" id="input-{{field.name}}" ng-model="properties[field.name]">
-            <option value="">{{ 'anol.featureform.PLEASE_CHOOSE' | translate }}</option>
-            <option ng-repeat="option in field.select" ng-value="getOptionValue(option)">{{ getOptionLabel(option) }}</option>
+    <div ng-repeat="field in formFields"
+         class="form-group"
+         ng-class="{ 'has-error': highlightInvalid && !isValid(field) }"
+    >
+        <label for="input-{{field.name}}">
+            {{ field.label || field.name }}{{ field.required ? ' (*)' : ''}}
+        </label>
+        <input ng-if="field.type !== 'select'"
+               id="input-{{field.name}}"
+               class="form-control"
+               type="{{field.type}}"
+               ng-model="properties[field.name]"
+        />
+        <select ng-if="field.type === 'select'"
+                id="input-{{field.name}}"
+                class="form-control"
+                ng-model="properties[field.name]"
+        >
+            <option value="">
+                {{ 'anol.featureform.PLEASE_CHOOSE' | translate }}
+            </option>
+            <option ng-repeat="option in field.select"
+                    ng-value="getOptionValue(option)"
+            >
+                {{ getOptionLabel(option) }}
+            </option>
         </select>
+        <small ng-if="highlightInvalid && !isValid(field)"
+               class="help-block">
+            {{ 'anol.featureform.IS_REQUIRED' | translate }}
+        </small>
     </div>
 </form>
 

--- a/src/modules/featureform/templates/featureform.html
+++ b/src/modules/featureform/templates/featureform.html
@@ -1,10 +1,10 @@
 <form class="container-fluid" style="padding-top: 2em">
     <div ng-repeat="field in formFields" class="form-group">
-        <label for="input-{{field.name}}">{{ field.label }}</label>
-        <input ng-if="field.type !== 'select'" class="form-control" type="{{field.type}}" id="input-{{field.name}}" ng-model="formValues[field.name]"/>
-        <select ng-if="field.type === 'select'" class="form-control" id="input-{{field.name}}"  ng-model="formValues[field.name]">
+        <label for="input-{{field.name}}">{{ field.label || field.name }}</label>
+        <input ng-if="field.type !== 'select'" class="form-control" type="{{field.type}}" id="input-{{field.name}}" ng-model="properties[field.name]"/>
+        <select ng-if="field.type === 'select'" class="form-control" id="input-{{field.name}}" ng-model="properties[field.name]">
             <option value="">{{ 'anol.featureform.PLEASE_CHOOSE' | translate }}</option>
-            <option ng-repeat="option in field.select" ng-value="option.value">{{ option.label }}</option>
+            <option ng-repeat="option in field.select" ng-value="getOptionValue(option)">{{ getOptionLabel(option) }}</option>
         </select>
     </div>
 </form>

--- a/src/modules/module.js
+++ b/src/modules/module.js
@@ -46,7 +46,8 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                     'COULD_NOT_READ_FILE': 'Could not read file'
                 },
                 'featureform': {
-                    'PLEASE_CHOOSE': 'Please choose ...'
+                    'PLEASE_CHOOSE': 'Please choose ...',
+                    'IS_REQUIRED': 'This field is required'
                 },
                 'featurepropertieseditor': {
                     'NEW_PROPERTY': 'New property'
@@ -138,7 +139,8 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                     'DRAW_LAYER_TITLE': 'Zeichenlayer'
                 },
                 'featureform': {
-                    'PLEASE_CHOOSE': 'Bitte auswählen ...'
+                    'PLEASE_CHOOSE': 'Bitte auswählen ...',
+                    'IS_REQUIRED': 'Dies ist ein Pflichtfeld'
                 },
                 'featurestyleeditor': {
                     'EDIT_FEATURE_STYLE': 'Feature Style bearbeiten',

--- a/src/modules/module.js
+++ b/src/modules/module.js
@@ -47,7 +47,8 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                 },
                 'featureform': {
                     'PLEASE_CHOOSE': 'Please choose ...',
-                    'IS_REQUIRED': 'This field is required'
+                    'IS_REQUIRED': 'This field is required',
+                    'INPUT_NOT_SUPPORTED': 'The following configured input type is not supported: '
                 },
                 'featurepropertieseditor': {
                     'NEW_PROPERTY': 'New property'
@@ -140,7 +141,8 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                 },
                 'featureform': {
                     'PLEASE_CHOOSE': 'Bitte auswählen ...',
-                    'IS_REQUIRED': 'Dies ist ein Pflichtfeld'
+                    'IS_REQUIRED': 'Dies ist ein Pflichtfeld',
+                    'INPUT_NOT_SUPPORTED': 'Der folgende konfigurierte Inputtyp ist nicht unterstützt: '
                 },
                 'featurestyleeditor': {
                     'EDIT_FEATURE_STYLE': 'Feature Style bearbeiten',

--- a/src/modules/module.js
+++ b/src/modules/module.js
@@ -6,11 +6,10 @@
  */
 
 require('angular-ui-bootstrap');
-require('ui-select');
 require('angular-translate');
 require('angular-sanitize');
 
-angular.module('anol', ['ui.bootstrap', 'ui.select', 'pascalprecht.translate', 'ngSanitize'])
+angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
 /**
  * @ngdoc object
  * @name anol.constant:DefaultMapName


### PR DESCRIPTION
read write values to feature properties.
support different forms for different geometry types.
required fields.
ui stuff.

If a field is required, a `(*)` will be shown after the label. If the property `highlightInvalid` of `anol-feature-form` is set to true, the input will be highlighted if it is required and has no value. This is done so we can later set this property if we want to highlight required fields after a user wants to submit invalid data.