### PR TITLE
add simple popup print (2)

### DIFF
--- a/src/modules/getfeatureinfo/getfeatureinfo-directive.js
+++ b/src/modules/getfeatureinfo/getfeatureinfo-directive.js
@@ -114,7 +114,7 @@ angular.module('anol.getfeatureinfo')
                                 }
                                 var iframe;
                                 if(featureInfoObject.target === '_popup') {
-                                    iframe = $('<iframe seamless src="' + featureInfoObject.url + '"></iframe>');
+                                    iframe = $('<iframe seamless id="feature_info_iframe" src="' + featureInfoObject.url + '"></iframe>');
                                 }
                                 switch(featureInfoObject.target) {
                                     case '_blank':


### PR DESCRIPTION
we need a simple possibility to print the featureinfo responses. So I add an id to the featureinfo iframe and a little print button to the featureinfo popup.