### PR TITLE
Fix sorting of the catalog groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "napa": "^3.0.0",
     "ol": "^5.2.0",
     "ol-ext": "^3.0.1",
-    "proj4": "^2.4.4"
+    "proj4": "^2.4.4",
+    "voca": "^1.4.0"
   },
   "scripts": {
     "pretest": "npm run lint",

--- a/src/modules/catalog/catalog-directive.js
+++ b/src/modules/catalog/catalog-directive.js
@@ -101,7 +101,7 @@ angular.module('anol.catalog')
             };
         })
         // filter directive needed when we want to be able to sort the objects on the catalog.
-        // It's not possible to siort on an object
+        // It's not possible to sort on an object
         .filter("catalogToArray", function(){
           return function(obj) {
               return Object

--- a/src/modules/catalog/catalog-directive.js
+++ b/src/modules/catalog/catalog-directive.js
@@ -47,7 +47,7 @@ angular.module('anol.catalog')
                         scope.sortedLayers = sorted.layers;
                         scope.removeWaiting();
                     });
-
+                    
                     scope.addedGroups = CatalogService.addedGroupsName;
                     scope.addedLayers = CatalogService.addedLayersName;
                     
@@ -99,4 +99,15 @@ angular.module('anol.catalog')
                     });
                 } 
             };
-        });
+        })
+        // filter directive needed when we want to be able to sort the objects on the catalog.
+        // It's not possible to siort on an object
+        .filter("catalogToArray", function(){
+          return function(obj) {
+              return Object
+                .entries(obj)
+                .map(function(entry){
+                  return entry[1]
+                })
+          };
+      });

--- a/src/modules/catalog/catalog-service.js
+++ b/src/modules/catalog/catalog-service.js
@@ -1,4 +1,5 @@
 import './module.js';
+import voca from 'voca';
 
 angular.module('anol.catalog')
 
@@ -82,7 +83,8 @@ angular.module('anol.catalog')
                         self.firstLetters.push(firstLetter);
                         sortedLayers[firstLetter] = {
                             'layers':  [_layer],
-                            'title': firstLetter
+                            'title': firstLetter,
+                            'localeTitle': voca.latinise(firstLetter)
                         };
                     } 
                     else {
@@ -130,7 +132,8 @@ angular.module('anol.catalog')
                         self.firstLettersGroups.push(firstLetter);
                         sortedGroups[firstLetter] = {
                             'layers':  [_group],
-                            'title': firstLetter
+                            'title': firstLetter,
+                            'localeTitle': voca.latinise(firstLetter)
                         };
                     } 
                     else {

--- a/src/modules/catalog/catalog-service.js
+++ b/src/modules/catalog/catalog-service.js
@@ -84,7 +84,7 @@ angular.module('anol.catalog')
                         sortedLayers[firstLetter] = {
                             'layers':  [_layer],
                             'title': firstLetter,
-                            'localeTitle': voca.latinise(firstLetter)
+                            'latinisedTitle': voca.latinise(firstLetter)
                         };
                     } 
                     else {
@@ -133,7 +133,7 @@ angular.module('anol.catalog')
                         sortedGroups[firstLetter] = {
                             'layers':  [_group],
                             'title': firstLetter,
-                            'localeTitle': voca.latinise(firstLetter)
+                            'latinisedTitle': voca.latinise(firstLetter)
                         };
                     } 
                     else {


### PR DESCRIPTION
- Added new catalog filter directive to transform object into an array, to make sorting in the groups by some parameter possible. -
- Added new library to latinise charcaters ([VOCA JS](https://vocajs.com/)) 
- Added new property `localeTitle` on sortedGroups and sortedLayers for correcting sorting of the characters