### PR TITLE
rework combinable and do not combine if one layer has opacity set.

### DIFF
--- a/src/anol/layer.js
+++ b/src/anol/layer.js
@@ -117,10 +117,10 @@ class AnolBaseLayer {
         delete this.olLayer;
     }
     isCombinable(other) {
-        if(other.CLASS_NAME !== this.CLASS_NAME) {
-            return false;
-        }
-        return true;
+        return other.CLASS_NAME === this.CLASS_NAME;
+    }
+    isCombinableInGroup(other) {
+        return false;
     }
     isClustered() {
         return false;

--- a/src/anol/layer/basewms.js
+++ b/src/anol/layer/basewms.js
@@ -34,8 +34,9 @@ class BaseWMS extends AnolBaseLayer {
     }
 
     isCombinable(other) {
-        return this.isCombinableInGroup(other) &&
-            (angular.isUndefined(other.anolGroup) || other.anolGroup.isCombinable());
+        return angular.isDefined(other.anolGroup) ?
+            other.anolGroup.childrenAreCombinable() :
+            this.isCombinableInGroup(other);
     }
 
     isCombinableInGroup(other) {

--- a/src/anol/layer/basewms.js
+++ b/src/anol/layer/basewms.js
@@ -34,37 +34,23 @@ class BaseWMS extends AnolBaseLayer {
     }
 
     isCombinable(other) {
-        var combinable = super.isCombinable(other);
-        if(!combinable) {
-            return false;
-        }
-        if (angular.isDefined(other.anolGroup)) {
-            combinable = other.anolGroup.isCombinable();
-            if(!combinable) {
-                return false;
-            }
-        }
-        if(this.olSourceOptions.url !== other.olSourceOptions.url) {
-            return false;
-        }
-        if (this.isBackground) {
-            return false;
-        }
-        var thisParams = $.extend(true, {}, this.olSourceOptions.params);
-        delete thisParams.LAYERS;
-        var otherParams = $.extend(true, {}, other.olSourceOptions.params);
-        delete otherParams.LAYERS;
-        if(!angular.equals(thisParams, otherParams)) {
-            return false;
-        }
-        if(!angular.equals(this.anolGroup, other.anolGroup)) {
-            return false;
-        }
+        return this.isCombinableInGroup(other) &&
+            (angular.isUndefined(other.anolGroup) || other.anolGroup.isCombinable());
+    }
 
-        if (this.catalog) {
-            return false;
-        }
-        return true;
+    isCombinableInGroup(other) {
+        var ownParams = angular.merge({}, this.olSourceOptions.params);
+        delete ownParams.LAYERS;
+        var otherParams = angular.merge({}, other.olSourceOptions.params);
+        delete otherParams.LAYERS;
+
+        return super.isCombinable(other) &&
+            this.olSourceOptions.url === other.olSourceOptions.url &&
+            !this.isBackground &&
+            angular.equals(ownParams, otherParams) &&
+            angular.equals(this.anolGroup, other.anolGroup) &&
+            !this.catalog &&
+            angular.isUndefined(this.options.opacity) && angular.isUndefined(other.options.opacity);
     }
 
     getCombinedSource(other) {
@@ -92,7 +78,7 @@ class BaseWMS extends AnolBaseLayer {
             }
             olSource.set('anolLayers', anolLayers);
 
-            // update layer params 
+            // update layer params
             var layerParams = [];
             angular.forEach(anolLayers, function(layer) {
                 if (layer.getVisible()) {
@@ -102,7 +88,7 @@ class BaseWMS extends AnolBaseLayer {
             var params = olSource.getParams();
             params.LAYERS = layerParams.reverse().join(',');
             olSource.updateParams(params);
-        } 
+        }
     }
     getVisible() {
         if(angular.isUndefined(this.olLayer)) {
@@ -121,11 +107,11 @@ class BaseWMS extends AnolBaseLayer {
         var params = olSource.getParams();
         params.LAYERS = layerParams.reverse().join(',');
         olSource.updateParams(params);
-    }    
+    }
     setVisible(visible) {
         if (visible == this.getVisible()) {
             return;
-        }     
+        }
         var insertLayerIdx = 0;
         var source = this.olLayer.getSource();
         var self = this;

--- a/src/anol/layer/dynamicgeojson.js
+++ b/src/anol/layer/dynamicgeojson.js
@@ -28,6 +28,7 @@ import Stroke from 'ol/style/Stroke';
 import {containsCoordinate} from 'ol/extent';
 
 import GeoJSON from 'ol/format/GeoJSON';
+import AnolBaseLayer from "../layer";
 
 class DynamicGeoJSON extends StaticGeoJSON {
 
@@ -41,7 +42,7 @@ class DynamicGeoJSON extends StaticGeoJSON {
             this.additionalRequestParameters = _options.olLayer.source.additionalParameters;
         }
         this.CLASS_NAME = 'anol.layer.DynamicGeoJSON';
-    
+
         this.olSourceOptions = this._createSourceOptions(_options.olLayer.source);
         delete _options.olLayer.source;
         this.olLayerOptions = _options.olLayer;
@@ -54,19 +55,10 @@ class DynamicGeoJSON extends StaticGeoJSON {
     }
 
     isCombinable(other) {
-        if(other.CLASS_NAME !== this.CLASS_NAME) {
-            return false;
-        }
-        if(this.olSourceOptions.url !== other.olSourceOptions.url) {
-            return false;
-        }
-        if(this.olSourceOptions.featureProjection !== other.olSourceOptions.featureProjection) {
-            return false;
-        }
-        if(this.clusterOptions !== false && this.anolGroup !== other.anolGroup) {
-            return false;
-        }
-        return true;
+        return AnolBaseLayer.prototype.isCombinable.call(this, other) &&
+            this.olSourceOptions.url === other.olSourceOptions.url &&
+            this.olSourceOptions.featureProjection === other.olSourceOptions.featureProjection &&
+            (this.clusterOptions === false || this.anolGroup === other.anolGroup);
     }
 
     getCombinedSource(other) {
@@ -281,7 +273,7 @@ class DynamicGeoJSON extends StaticGeoJSON {
                 styles.push(defaultStyle);
                 if (angular.isUndefined(styleDefinition.fontOffsetY)) {
                     styleDefinition.fontOffsetY = value.layer.style.graphicHeight;
-                } 
+                }
                 styles.push(new Style({
                     text: self.createTextStyle(
                         styleDefinition,

--- a/src/anol/layer/group.js
+++ b/src/anol/layer/group.js
@@ -78,20 +78,19 @@ class Group {
         angular.element(this).off('anol.group.visible:change', func);
     }
 
-    isCombinable() {
-        // check if check was alredy done for group
-        if (angular.isDefined(this.combinable)) {
-            return this.combinable;
+    childrenAreCombinable() {
+        if (angular.isDefined(this.childrenCombinable)) {
+            return this.childrenCombinable;
         }
 
-        this.combinable = this.layers
+        this.childrenCombinable = this.layers
             .slice(1)
             .every((layer, i) => {
                 const last = this.layers[i];
                 return last.isCombinableInGroup(layer);
             });
 
-        return this.combinable;
+        return this.childrenCombinable;
     }
 }
 

--- a/src/anol/layer/group.js
+++ b/src/anol/layer/group.js
@@ -16,7 +16,7 @@ class Group {
 
     constructor(options) {
         var self = this;
-        this.CLASS_NAME = 'anol.layer.Group';    
+        this.CLASS_NAME = 'anol.layer.Group';
         this.name = options.name;
         this.title = options.title;
         this.layers = options.layers;
@@ -76,30 +76,22 @@ class Group {
     }
     offVisibleChange(func) {
         angular.element(this).off('anol.group.visible:change', func);
-    }    
+    }
+
     isCombinable() {
         // check if check was alredy done for group
-        if (angular.isDefined(combinable)) {
-            return combinable;
+        if (angular.isDefined(this.combinable)) {
+            return this.combinable;
         }
-        var lastClass = undefined;
-        var lastUrl = undefined;
-        var combinable = true;
-        var self = this;
-        $.each(self.layers, function(idx, layer) {
-            if(angular.isDefined(lastClass) && layer.CLASS_NAME !== lastClass) {
-                combinable = false;
-                return;
-            }
-            lastClass = layer.CLASS_NAME;
-            if(angular.isDefined(lastUrl)  && layer.olSourceOptions.url !== lastUrl) {
-                combinable = false;
-                return;
-            }
-            lastUrl = layer.olSourceOptions.url;
-        });
-        this.combinable = combinable;
-        return combinable;
+
+        this.combinable = this.layers
+            .slice(1)
+            .every((layer, i) => {
+                const last = this.layers[i];
+                return last.isCombinableInGroup(layer);
+            });
+
+        return this.combinable;
     }
 }
 

--- a/src/anol/layer/tms.js
+++ b/src/anol/layer/tms.js
@@ -15,7 +15,7 @@
  */
 
 import AnolBaseLayer from '../layer.js';
-   
+
 import {getWidth, getHeight, getBottomLeft} from 'ol/extent';
 import TileLayer from 'ol/layer/Tile';
 import XYZ from 'ol/source/XYZ';
@@ -97,7 +97,6 @@ class TMS extends AnolBaseLayer {
         return url;
     }
     isCombinable() {
-        this.combinable = false;
         return false;
     }
 }

--- a/src/anol/layer/wmts.js
+++ b/src/anol/layer/wmts.js
@@ -26,7 +26,7 @@ import { getWidth, getHeight, getTopLeft} from 'ol/extent';
 import { DEVICE_PIXEL_RATIO } from 'ol/has';
 
 class WMTS extends AnolBaseLayer {
-    
+
     constructor(_options) {
         var defaults = {
             olLayer: {
@@ -110,9 +110,8 @@ class WMTS extends AnolBaseLayer {
         return srcOptions;
     }
     isCombinable() {
-        this.combinable = false;
         return false;
     }
 }
 
-export default WMTS; 
+export default WMTS;


### PR DESCRIPTION
This disallows wms to be combined if one has an opacity set.

Also this reworks the combinable logic, especially regarding groups. A group is now considered combinable if all child layers are combinable (there were some cases that were not considered before).

A new method `isCombinableInGroup` is introduced which is `false` for all layers but wms. WMS are only combinable if the group is combinable. The new method avoids infinite recursion.