### PR TITLE
Permalink rework

### DIFF
--- a/src/anol/layer.js
+++ b/src/anol/layer.js
@@ -6,7 +6,7 @@
  * @param {string} options.title Layer title
  * @param {string} options.displayInLayerswitcher Show in layerswitcher
  * @param {boolean} options.permalink Add layer to permalink url. Default true. When displayInLayerswitcher is false, permalink is always false.
- * @param {boolean} options.isBackgorund Define layer as background layer
+ * @param {boolean} options.isBackground Define layer as background layer
  * @param {Object} options.featureinfo Stores informations for feature info
  * @param {string} options.featureinfo.target Target of *GetFeatureInfo* request for {@link api/anol.featureinfo anol.featureinfo}. Supported values are:
  * - *_popup* - Results displayed in a popup

--- a/src/modules/map/layers-service.js
+++ b/src/modules/map/layers-service.js
@@ -134,7 +134,7 @@ angular.module('anol.map')
          * @name addBackgroundLayer
          * @methodOf anol.map.LayersService
          * @param {anol.layer} layer Background layer to add
-         * @param {number} idx Position to add backgorund layer at
+         * @param {number} idx Position to add background layer at
          * @description
          * Adds a background layer
          */

--- a/src/modules/permalink/permalink-service.js
+++ b/src/modules/permalink/permalink-service.js
@@ -1,73 +1,73 @@
 import './module.js';
-import { transform, transformExtent } from 'ol/proj';
+import {transform, transformExtent} from 'ol/proj';
 
 angular.module('anol.permalink')
 
-/**
- * @ngdoc object
- * @name anol.permalink.PermalinkServiceProvider
- */
-    .provider('PermalinkService', [function() {
+    /**
+     * @ngdoc object
+     * @name anol.permalink.PermalinkServiceProvider
+     */
+    .provider('PermalinkService', [function () {
         var _urlCrs;
         var _precision = 100000;
 
-        var getParamString = function(param, params) {
-            if(angular.isUndefined(params[param])) {
+        var getParamString = function (param, params) {
+            if (angular.isUndefined(params[param])) {
                 return false;
             }
             var p = params[param];
-            if(angular.isArray(p)) {
-                p = p[p.length -1];
+            if (angular.isArray(p)) {
+                p = p[p.length - 1];
             }
             return p;
         };
 
-        var extractMapParams = function(params) {
+        var extractMapParams = function (params) {
             var mapParam = getParamString('map', params);
             var mapParams;
-            if(mapParam !== false) {
+            if (mapParam !== false) {
                 mapParams = mapParam.split(',');
             }
 
             var layersParam = getParamString('layers', params);
             var layers;
-            if(layersParam !== false) {
+            if (layersParam !== false) {
                 layers = layersParam.split(',');
             }
 
             var defaultOverlaysParam = getParamString('defaultOverlays', params);
             var defaultOverlays;
-            if(defaultOverlaysParam !== false) {
-              defaultOverlays = defaultOverlaysParam.split(',');
+            if (defaultOverlaysParam !== false) {
+                defaultOverlays = defaultOverlaysParam.split(',');
             }
 
             var backgroundLayerParam = getParamString('backgroundLayer', params);
             var backgroundLayer;
-            if(backgroundLayerParam !== false) {
-              backgroundLayer = backgroundLayerParam;
+            if (backgroundLayerParam !== false) {
+                backgroundLayer = backgroundLayerParam;
             }
 
             var visibleCatalogLayersParam = getParamString('visibleCatalogLayers', params);
             var visibleCatalogLayers;
-            if(visibleCatalogLayersParam !== false) {
+            if (visibleCatalogLayersParam !== false) {
                 visibleCatalogLayers = visibleCatalogLayersParam.split(',');
             }
 
             var catalogLayersParam = getParamString('catalogLayers', params);
             var catalogLayers;
-            if(catalogLayersParam !== false) {
+            if (catalogLayersParam !== false) {
                 catalogLayers = catalogLayersParam.split(',');
             }
 
             var visibleCatalogGroupsParam = getParamString('visibleCatalogGroups', params);
             var visibleCatalogGroups;
-            if(visibleCatalogGroupsParam !== false) {
+            if (visibleCatalogGroupsParam !== false) {
                 visibleCatalogGroups = visibleCatalogGroupsParam.split(',');
             }
 
             var catalogGroupsParam = getParamString('catalogGroups', params);
             var catalogGroups;
-            if(catalogGroupsParam !== false) {
+            if (catalogGroupsParam !== false) {
                 catalogGroups = catalogGroupsParam.split(',');
             }
 
@@ -78,7 +78,7 @@ angular.module('anol.permalink')
             }
 
             var result = {}
-            if(angular.isDefined(mapParams)) {
+            if (angular.isDefined(mapParams)) {
                 if (mapParams.length === 4) {
                     result = {
                         'zoom': parseInt(mapParams[0]),
@@ -91,31 +91,31 @@ angular.module('anol.permalink')
                 }
             }
 
-            if(angular.isDefined(layers)) {
+            if (angular.isDefined(layers)) {
                 result.layers = layers;
             }
 
-            if(angular.isDefined(defaultOverlays)) {
-              result.defaultOverlays = defaultOverlays;
+            if (angular.isDefined(defaultOverlays)) {
+                result.defaultOverlays = defaultOverlays;
             }
 
-            if(angular.isDefined(backgroundLayer)) {
-              result.backgroundLayer = backgroundLayer;
+            if (angular.isDefined(backgroundLayer)) {
+                result.backgroundLayer = backgroundLayer;
             }
 
-            if(angular.isDefined(catalogLayers)) {
-               result.catalogLayers = catalogLayers;
+            if (angular.isDefined(catalogLayers)) {
+                result.catalogLayers = catalogLayers;
             }
 
-            if(angular.isDefined(visibleCatalogLayers)) {
+            if (angular.isDefined(visibleCatalogLayers)) {
                 result.visibleCatalogLayers = visibleCatalogLayers;
             }
 
-            if(angular.isDefined(catalogGroups)) {
+            if (angular.isDefined(catalogGroups)) {
                 result.catalogGroups = catalogGroups;
             }
 
-            if(angular.isDefined(visibleCatalogGroups)) {
+            if (angular.isDefined(visibleCatalogGroups)) {
                 result.visibleCatalogGroups = visibleCatalogGroups;
             }
 
@@ -136,46 +136,68 @@ angular.module('anol.permalink')
         };
 
         /**
-     * @ngdoc method
-     * @name setUrlCrs
-     * @methodOf anol.permalink.PermalinkServiceProvider
-     * @param {string} crs EPSG code of coordinates in url
-     * @description
-     * Define crs of coordinates in url
-     */
-        this.setUrlCrs = function(crs) {
+         * @ngdoc method
+         * @name setUrlCrs
+         * @methodOf anol.permalink.PermalinkServiceProvider
+         * @param {string} crs EPSG code of coordinates in url
+         * @description
+         * Define crs of coordinates in url
+         */
+        this.setUrlCrs = function (crs) {
             _urlCrs = crs;
         };
 
         /**
-     * @ngdoc method
-     * @name setPrecision
-     * @methodOf anol.permalink.PermalinkServiceProvider
-     * @param {number} precision Precision of coordinates in url
-     * @description
-     * Define precision of coordinates in url
-     */
-        this.setPrecision = function(precision) {
+         * @ngdoc method
+         * @name setPrecision
+         * @methodOf anol.permalink.PermalinkServiceProvider
+         * @param {number} precision Precision of coordinates in url
+         * @description
+         * Define precision of coordinates in url
+         */
+        this.setPrecision = function (precision) {
             _precision = precision;
         };
 
         this.$get = ['$rootScope', '$q', '$location', 'MapService', 'LayersService', 'CatalogService',
-            function($rootScope, $q, $location, MapService, LayersService, CatalogService) {
+            function ($rootScope, $q, $location, MapService, LayersService, CatalogService) {
+
+                function arrayChanges(newArray, oldArray) {
+                    newArray = angular.isDefined(newArray) ? newArray : [];
+                    oldArray = angular.isDefined(oldArray) ? oldArray : [];
+                    return {
+                        added: newArray.filter(item => oldArray.indexOf(item) < 0),
+                        removed: oldArray.filter(item => newArray.indexOf(item) < 0)
+                    };
+                }
+
+                function permalinkLayers(layers) {
+                    return layers
+                        .filter(l => angular.isDefined(l) && angular.isDefined(l.name))
+                        .flatMap(l => l instanceof anol.layer.Group ? l.layers : [l])
+                        .filter(l => l.permalink === true);
+                }
+
+                function backgroundLayers(layers) {
+                    return layers
+                        .filter(l => angular.isDefined(l) && l.isBackground);
+                }
+
                 /**
-         * @ngdoc service
-         * @name anol.permalink.PermalinkService
-         *
-         * @requires $rootScope
-         * @requires $location
-         * @requires anol.map.MapService
-         * @requires anol.map.LayersService
-         *
-         * @description
-         * Looks for a `map`-parameter in current url and move map to location specified in
-         *
-         * Updates browser-url with current zoom and location when map moved
-         */
-                var Permalink = function(urlCrs, precision) {
+                 * @ngdoc service
+                 * @name anol.permalink.PermalinkService
+                 *
+                 * @requires $rootScope
+                 * @requires $location
+                 * @requires anol.map.MapService
+                 * @requires anol.map.LayersService
+                 *
+                 * @description
+                 * Looks for a `map`-parameter in current url and move map to location specified in
+                 *
+                 * Updates browser-url with current zoom and location when map moved
+                 */
+                var Permalink = function (urlCrs, precision) {
                     var self = this;
                     self.precision = precision;
                     self.zoom = undefined;
@@ -184,12 +206,14 @@ angular.module('anol.permalink')
                     self.deferred = undefined;
                     self.map = MapService.getMap();
                     self.view = self.map.getView();
-                    self.sortedByGroupVisibleLayers = [];
-                    self.visibleLayerNames = [];
+                    self.visibleLayers = [];
+                    self.visibleGroups = [];
                     self.visibleDefaultOverlays = [];
                     self.backgroundLayer = [];
-                    self.visibleCatalogLayerNames = [];
-                    self.catalogLayerNames = [];
+                    self.visibleCatalogLayers = [];
+                    self.catalogLayers = [];
+                    self.visibleCatalogGroups = [];
+                    self.catalogGroups = [];
 
                     self.urlCrs = urlCrs;
                     if (angular.isUndefined(self.urlCrs)) {
@@ -198,58 +222,50 @@ angular.module('anol.permalink')
                     }
 
                     var params = $location.search();
-                    
+
                     var mapParams = extractMapParams(params);
-                    if(mapParams !== false) {
+                    if (mapParams !== false) {
                         self.updateMapFromParameters(mapParams);
                     } else {
-                        angular.forEach(LayersService.flattedLayers(), function(layer) {
-                            if(layer.permalink === true) {
-                                if(layer.getVisible()) {
-                                    self.sortedByGroupVisibleLayers.push(layer);
-                                    self.visibleLayerNames.push(layer.name);
-                                    if(layer.anolGroup) {
-                                      self.visibleLayerGroups.push(layer.anolGroup.name)
+                        angular.forEach(LayersService.flattedLayers(), function (layer) {
+                            if (layer.permalink === true) {
+                                if (layer.getVisible()) {
+                                    self.visibleLayers.push(layer);
+                                    if (layer.anolGroup) {
+                                        self.visibleGroups.push(layer.anolGroup)
                                     }
                                 }
                             }
+                            if (layer.isBackground && layer.getVisible()) {
+                                self.backgroundLayer = layer;
+                            }
                         });
                     }
-                    self.map.on('moveend', function() {
+                    self.map.on('moveend', function () {
                         self.moveendHandler();
                     }.bind(self));
 
-                    function arrayChanges(newArray, oldArray) {
-                        newArray = angular.isDefined(newArray) ? newArray : [];
-                        oldArray = angular.isDefined(oldArray) ? oldArray : [];
-                        return {
-                            added: newArray.filter(item => oldArray.indexOf(item) < 0),
-                            removed: oldArray.filter(item => newArray.indexOf(item) < 0)
-                        };
+                    for (const layer of LayersService.flattedLayers()) {
+                        if (layer.isBackground || layer.permalink) {
+                            layer.onVisibleChange(self.handleVisibleChange, self);
+                        }
                     }
 
-                    function permalinkLayers(layers) {
-                        return layers
-                            .filter(l => angular.isDefined(l) && angular.isDefined(l.name))
-                            .flatMap(l => l instanceof anol.layer.Group ? l.layers : [l])
-                            .filter(l => l.permalink === true);
-                    }
-
-                    $rootScope.$watchCollection(function() {
+                    $rootScope.$watchCollection(function () {
                         return LayersService.layers();
-                    }, function(newVal, oldVal) {
-                        const { added, removed } = arrayChanges(newVal, oldVal);
+                    }, function (newVal, oldVal) {
+                        const {added, removed} = arrayChanges(newVal, oldVal);
 
                         if (added.length + removed.length === 0) {
                             return;
                         }
 
-                        self.visibleLayerNames = [];
+                        self.visibleLayers = [];
 
                         for (const layer of permalinkLayers(added)) {
                             layer.onVisibleChange(self.handleVisibleChange, self);
                             if (layer.getVisible()) {
-                                self.visibleLayerNames.push(layer.name);
+                                self.visibleLayers.push(layer);
                             }
                         }
 
@@ -257,34 +273,42 @@ angular.module('anol.permalink')
                             layer.offVisibleChange(self.handleVisibleChange);
                         }
 
+                        for (const bgLayer of backgroundLayers(added)) {
+                            layer.onVisibleChange(self.handleVisibleChange, self);
+                        }
+
+                        for (const bgLayer of backgroundLayers(removed)) {
+                            layer.offVisibleChange(self.handleVisibleChange);
+                        }
+
                         self.generatePermalink();
                     });
 
-                    $rootScope.$watchCollection(function() {
+                    $rootScope.$watchCollection(function () {
                         return CatalogService.addedCatalogGroups();
-                    }, function(newVal, oldVal) {
-                        const { added, removed } = arrayChanges(newVal, oldVal);
+                    }, function (newVal, oldVal) {
+                        const {added, removed} = arrayChanges(newVal, oldVal);
 
                         if (added.length + removed.length === 0) {
                             return;
                         }
 
-                        self.catalogGroupNames = [];
-                        self.visibleCatalogGroupNames = [];
-                        self.visibleCatalogLayerNames = [];
+                        self.catalogGroups = [];
+                        self.visibleCatalogGroups = [];
+                        self.visibleCatalogLayers = [];
 
                         for (const group of added) {
                             group.onVisibleChange(self.handleVisibleChange, self);
                             for (const layer of group.layers) {
                                 layer.onVisibleChange(self.handleVisibleChange, self);
                                 if (layer.getVisible()) {
-                                    self.visibleCatalogLayerNames.push(layer.name);
+                                    self.visibleCatalogLayers.push(layer);
                                 }
                             }
 
-                            self.catalogGroupNames.push(group.name);
+                            self.catalogGroups.push(group);
                             if (group.getVisible()) {
-                                self.visibleCatalogGroupNames.push(group.name);
+                                self.visibleCatalogGroups.push(group);
                             }
                         }
 
@@ -298,23 +322,23 @@ angular.module('anol.permalink')
                         self.generatePermalink();
                     });
 
-                    $rootScope.$watchCollection(function() {
+                    $rootScope.$watchCollection(function () {
                         return CatalogService.addedCatalogLayers();
-                    }, function(newVal, oldVal) {
-                        const { added, removed } = arrayChanges(newVal, oldVal);
+                    }, function (newVal, oldVal) {
+                        const {added, removed} = arrayChanges(newVal, oldVal);
 
                         if (added.length + removed.length === 0) {
                             return;
                         }
 
-                        self.catalogLayerNames = [];
-                        self.visibleCatalogLayerNames = [];
+                        self.catalogLayers = [];
+                        self.visibleCatalogLayers = [];
 
                         for (const layer of added) {
                             layer.onVisibleChange(self.handleVisibleChange);
-                            self.catalogLayerNames.push(layer.name);
+                            self.catalogLayers.push(layer);
                             if (layer.getVisible()) {
-                                self.visibleCatalogLayerNames.push(layer.name);
+                                self.visibleCatalogLayers.push(layer);
                             }
                         }
 
@@ -329,78 +353,59 @@ angular.module('anol.permalink')
                 /**
                  * @private
                  */
-                Permalink.prototype.handleVisibleChange = function(evt) {
+                Permalink.prototype.handleVisibleChange = function (evt) {
                     var self = evt.data.context;
                     // this in this context is the layer, visible changed for
                     var layer = this;
                     var layerName = layer.name;
                     var layerGroup = layer.anolGroup;
-                    
-                    if(!layer.isBackground && layer.permalink === true) {
-                        if(angular.isDefined(layerName) && layer.getVisible()) {
-                          if(self.visibleLayerNames.length === 1 && self.visibleLayerNames[0] === '') {
-                            self.visibleLayerNames.splice(0,1)
-                          }
-                          if(layerGroup) {
-                            // push the layer to the array 
-                            self.sortedByGroupVisibleLayers.push(layer)
-                              
-                            // sort it by group name 
-                            self.sortedByGroupVisibleLayers
-                              .sort(function(a,b) {
-                                if(a.anolGroup.name < b.anolGroup.name) { return -1 }
-                                if(a.anolGroup.name > b.anolGroup.name) { return 1 }
-                                return 0;
-                              })
-                            // finally, make the visibleLayerNames array be a mapping of only
-                            // the layer names on names on sortedByGroupVisibleLayers
-                            self.visibleLayerNames = self.sortedByGroupVisibleLayers
-                              .map(sortedLayer => sortedLayer.name)
-                          } else {
-                            self.visibleLayerNames.push(layerName);
-                          }
-                        } else {
-                            var layerNameIdx = $.inArray(layerName, self.visibleLayerNames);
-                            var layerIdx = $.inArray(layer, self.sortedByGroupVisibleLayers);
-                            // remove the layer from the sortedByGroup array
-                            if(layerIdx > -1) {
-                              self.sortedByGroupVisibleLayers.splice(layerIdx, 1)
+
+                    if (!layer.isBackground && layer.permalink === true) {
+                        if (angular.isDefined(layerName) && layer.getVisible()) {
+                            if (self.visibleLayers.length === 1 && self.visibleLayers[0].name === '') {
+                                console.warn('why?') // TODO: remove
+                                self.visibleLayers.splice(0, 1);
                             }
-                            // remove the layer from the names array
-                            if(layerNameIdx > -1) {    
-                                self.visibleLayerNames.splice(layerNameIdx, 1);
+                            if (layerGroup) {
+                                self.visibleGroups.push(layerGroup);
+                            }
+                            self.visibleLayers.push(layerName);
+                        } else {
+                            var layerIdx = self.visibleLayers.indexOf(layer);
+                            // remove the layer from the sortedByGroup array
+                            if (layerIdx > -1) {
+                                self.visibleLayers.splice(layerIdx, 1);
                             }
                         }
                     }
 
-                    if(layer.isBackground) {
-                      layerName = layer.name;
-                      if(angular.isDefined(layerName) && layer.getVisible()) {
-                        self.backgroundLayer = layerName
-                      }
+                    if (layer.isBackground) {
+                        if (angular.isDefined(layer.name) && layer.getVisible()) {
+                            self.backgroundLayer = layer
+                        }
                     }
 
                     if (layer.catalogLayer === true) {
-                        if(layer instanceof anol.layer.Group || (layer.hasGroup() && layer.anolGroup.layers.length == 1)) {
+                        if (layer instanceof anol.layer.Group || (layer.hasGroup() && layer.anolGroup.layers.length == 1)) {
                             if (typeof layer.hasGroup == 'function' && layer.hasGroup()) {
                                 layerName = layer.anolGroup.name;
                             }
 
-                            if(angular.isDefined(layerName) && layer.getVisible()) {
-                                self.visibleCatalogGroupNames.push(layerName);
+                            if (angular.isDefined(layerName) && layer.getVisible()) {
+                                self.visibleCatalogGroups.push(layer);
                             } else {
-                                var layerNameIdx = $.inArray(layerName, self.visibleCatalogGroupNames);
-                                if(layerNameIdx > -1) {
-                                    self.visibleCatalogGroupNames.splice(layerNameIdx, 1);
+                                var layerIdx = self.visibleCatalogGroups.indexOf(layer);
+                                if (layerIdx > -1) {
+                                    self.visibleCatalogGroups.splice(layerIdx, 1);
                                 }
                             }
                         } else {
-                            if(angular.isDefined(layerName) && layer.getVisible()) {
-                                self.visibleCatalogLayerNames.push(layerName);
+                            if (angular.isDefined(layerName) && layer.getVisible()) {
+                                self.visibleCatalogLayers.push(layer);
                             } else {
-                                var layerNameIdx = $.inArray(layerName, self.visibleCatalogLayerNames);
-                                if(layerNameIdx > -1) {
-                                    self.visibleCatalogLayerNames.splice(layerNameIdx, 1);
+                                var layerIdx = self.visibleCatalogLayers.indexOf(layer);
+                                if (layerIdx > -1) {
+                                    self.visibleCatalogLayers.splice(layerIdx, 1);
                                 }
                             }
                         }
@@ -415,17 +420,30 @@ angular.module('anol.permalink')
                  * @description
                  * Get lat, lon and zoom after map stoped moving
                  */
-                Permalink.prototype.moveendHandler = function() {
+                Permalink.prototype.moveendHandler = function () {
                     var self = this;
                     var center = transform(self.view.getCenter(), self.view.getProjection().getCode(), self.urlCrs);
                     self.lon = Math.round(center[0] * self.precision) / self.precision;
                     self.lat = Math.round(center[1] * self.precision) / self.precision;
 
                     self.zoom = self.view.getZoom();
-                    $rootScope.$apply(function() {
+                    $rootScope.$apply(function () {
                         self.generatePermalink();
                     });
                 };
+
+                Permalink.prototype.sortedLayerNames = function () {
+                    return this.visibleLayers.sort(function (a, b) {
+                        if (a.anolGroup.name < b.anolGroup.name) {
+                            return -1
+                        }
+                        if (a.anolGroup.name > b.anolGroup.name) {
+                            return 1
+                        }
+                        return 0;
+                    }).map(layer => layer.name);
+                };
+
                 /**
                  * @private
                  * @name generatePermalink
@@ -434,48 +452,59 @@ angular.module('anol.permalink')
                  * @description
                  * Builds the permalink url addon
                  */
-                Permalink.prototype.generatePermalink = function() {
+                Permalink.prototype.generatePermalink = function () {
                     var self = this;
-                    if(angular.isUndefined(self.zoom) || angular.isUndefined(self.lon) || angular.isUndefined(self.lat)) {
+                    if (angular.isUndefined(self.zoom) || angular.isUndefined(self.lon) || angular.isUndefined(self.lat)) {
                         return;
                     }
 
                     $location.search('map', [self.zoom, self.lon, self.lat, self.urlCrs].join(','));
-                    $location.search('layers', self.visibleLayerNames.join(','));
+
+                    $location.search('layers', this.sortedLayerNames().join(','));
 
                     if (self.backgroundLayer.length !== 0) {
-                      $location.search('backgroundLayer', self.backgroundLayer);
+                        $location.search('backgroundLayer', self.backgroundLayer.name);
 
                     } else {
-                      $location.search('backgroundLayer', '');
+                        $location.search('backgroundLayer', '');
                     }
 
                     if (self.visibleDefaultOverlays.length !== 0) {
-                      $location.search('defaultOverlays', self.visibleDefaultOverlays.join(','));
+                        $location.search('defaultOverlays', self.visibleDefaultOverlays
+                            .map(layer => layer.name)
+                            .join(','));
                     } else {
-                      $location.search('defaultOverlays', null);
+                        $location.search('defaultOverlays', null);
                     }
 
-                    if (self.visibleCatalogLayerNames.length !== 0) {
-                        $location.search('visibleCatalogLayers', self.visibleCatalogLayerNames.join(','));
+                    if (self.visibleCatalogLayers.length !== 0) {
+                        $location.search('visibleCatalogLayers', self.visibleCatalogLayers
+                            .map(layer => layer.name)
+                            .join(','));
                     } else {
                         $location.search('visibleCatalogLayers', null);
                     }
 
-                    if (self.catalogLayerNames.length !== 0) {
-                        $location.search('catalogLayers', self.catalogLayerNames.join(','));
+                    if (self.catalogLayers.length !== 0) {
+                        $location.search('catalogLayers', self.catalogLayers
+                            .map(layer => layer.name)
+                            .join(','));
                     } else {
                         $location.search('catalogLayers', null);
                     }
 
-                    if (self.visibleCatalogGroupNames.length !== 0) {
-                        $location.search('visibleCatalogGroups', self.visibleCatalogGroupNames.join(','));
+                    if (self.visibleCatalogGroups.length !== 0) {
+                        $location.search('visibleCatalogGroups', self.visibleCatalogGroups
+                            .map(layer => layer.name)
+                            .join(','));
                     } else {
                         $location.search('visibleCatalogGroups', null);
                     }
 
-                    if (self.catalogGroupNames.length !== 0) {
-                        $location.search('catalogGroups', self.catalogGroupNames.join(','));
+                    if (self.catalogGroups.length !== 0) {
+                        $location.search('catalogGroups', self.catalogGroups
+                            .map(layer => layer.name)
+                            .join(','));
                     } else {
                         $location.search('catalogGroups', null);
                     }
@@ -485,100 +514,88 @@ angular.module('anol.permalink')
                     $location.replace();
                 };
 
-                Permalink.prototype.updateMapFromParameters = function(mapParams) {
+                Permalink.prototype.updateMapFromParameters = function (mapParams) {
                     var self = this;
-                    if(mapParams.center !== undefined) {
+                    if (mapParams.center !== undefined) {
                         var center = transform(mapParams.center, mapParams.crs, self.view.getProjection().getCode());
                         self.view.setCenter(center);
                         self.view.setZoom(mapParams.zoom);
                     }
 
-                    if(mapParams.defaultOverlays !== undefined) {
-                      self.visibleDefaultOverlays = mapParams.defaultOverlays
-                      angular.forEach(LayersService.overlayLayers, function(layer) {
-                        // find in the layers the overlay layers that are defined
-                        var visible = mapParams.defaultOverlays.indexOf(layer.name) !== -1;
-                        // if found then set its visibility to true
-                        layer.setVisible(visible); 
-                      })
-                    }
-
-                    if(mapParams.backgroundLayer !== undefined) {
-                      self.backgroundLayer = mapParams.backgroundLayer
-                      angular.forEach(LayersService.backgroundLayers, function(layer) {
-                        // find in the layers the background layer that is defined
-                        if(layer.isBackground && self.backgroundLayer === layer.name) {
-                          // if found then set its visibility to true
-                          layer.setVisible(true);
-                        } 
-                      })
-                    }
-
-                    if(mapParams.layers !== undefined) {
-                        angular.forEach(LayersService.layers(), function(layer) {
-                            // only overlay layers are grouped
-                            if(layer instanceof anol.layer.Group) {
-                                angular.forEach(layer.layers, function(groupLayer) {
-                                    if(groupLayer.permalink !== true) {
-                                        return;
-                                    }
-                                    var visible = mapParams.layers.indexOf(groupLayer.name) !== -1;
-                                    groupLayer.setVisible(visible);
-                                });
-                            } else {
-                                if(layer.permalink !== true) {
-                                    return;
-                                }
-                                var visible = mapParams.layers.indexOf(layer.name) > -1;
-                                layer.setVisible(visible);
+                    if (mapParams.defaultOverlays !== undefined) {
+                        self.visibleDefaultOverlays = [];
+                        for (const layer of LayersService.overlayLayers) {
+                            // find in the layers the overlay layers that are defined
+                            var visible = mapParams.defaultOverlays.indexOf(layer.name) !== -1;
+                            // if found then set its visibility to true
+                            layer.setVisible(visible);
+                            if (visible) {
+                                self.visibleDefaultOverlays.push(layer);
                             }
-                        });
+                        }
+                    }
+
+                    if (angular.isDefined(mapParams.backgroundLayer)) {
+                        self.backgroundLayer = LayersService.backgroundLayers
+                            .find(l => l.getVisible());
+
+                        setTimeout(() => {
+                            for (const layer of LayersService.backgroundLayers) {
+                                layer.setVisible(layer.name === mapParams.backgroundLayer)
+                            }
+                        }, 0)
+                    } else {
+                        self.backgroundLayer = LayersService.backgroundLayers
+                            .find(l => l.getVisible());
+                    }
+
+                    if (mapParams.layers !== undefined) {
+                        for (const layer of permalinkLayers(LayersService.layers())) {
+                            const visible = mapParams.layers.indexOf(layer.name) !== -1;
+                            layer.setVisible(visible);
+                        }
                     }
 
                     if (mapParams.catalogLayers !== undefined) {
-                        angular.forEach(mapParams.catalogLayers, function(layerName) {
-                            var visible = false;
-                            if (mapParams.visibleCatalogLayers) {
-                                visible = mapParams.visibleCatalogLayers.indexOf(layerName) > -1;
-                            }
+                        for (const layerName of mapParams.catalogLayers) {
+                            const visible = mapParams.visibleCatalogLayers &&
+                                mapParams.visibleCatalogLayers.indexOf(layerName) > -1;
                             CatalogService.addToMap(layerName, visible);
-                        });
+                        }
                     }
 
-                    var catalogGroups = [];
+                    var catalogGroupPromises = [];
                     if (mapParams.catalogGroups !== undefined) {
-                        angular.forEach(mapParams.catalogGroups, function(groupName) {
-                            var visible = false;
-                            if (mapParams.visibleCatalogGroups) {
-                                visible = mapParams.visibleCatalogGroups.indexOf(groupName) > -1;
-                            }
+                        for (const groupName of mapParams.catalogGroups) {
+                            const visible = mapParams.visibleCatalogGroups &&
+                                mapParams.visibleCatalogGroups.indexOf(groupName) > -1;
                             var group = CatalogService.addGroupToMap(groupName, visible);
-                            catalogGroups.push(group);
                             if (group) {
-                                group.then(function(group) {
+                                catalogGroupPromises.push(group);
+                                group.then(function (group) {
                                     if (group.layers.length > 1) {
-                                        angular.forEach(group.layers, function(layer){
+                                        for (const layer of group.layers) {
                                             if (mapParams.visibleCatalogLayers) {
-                                                var visibleLayer = mapParams.visibleCatalogLayers.indexOf(layer.name) > -1;
-                                                layer.setVisible(visibleLayer);
+                                                const visible = mapParams.visibleCatalogLayers.indexOf(layer.name) > -1;
+                                                layer.setVisible(visible);
                                             }
-                                        })
+                                        }
                                     }
                                 });
                             }
-                        });
+                        }
                     }
 
-                    if(mapParams.fit !== undefined) {
+                    if (mapParams.fit !== undefined) {
                         var extent = transformExtent(mapParams.fit.extent, mapParams.fit.crs, self.view.getProjection().getCode());
-                        this.map.once('postrender', function() {
+                        this.map.once('postrender', function () {
                             self.view.fit(extent);
                         });
                     }
 
                     if (angular.isDefined(self.deferred)) {
-                        if (catalogGroups.length !== 0) {
-                            $q.all(catalogGroups).then(function() {
+                        if (catalogGroupPromises.length !== 0) {
+                            $q.all(catalogGroupPromises).then(function () {
                                 self.deferred.resolve();
                             });
                         } else {
@@ -587,39 +604,38 @@ angular.module('anol.permalink')
                     }
                 };
 
-                Permalink.prototype.getSettings = function() {
-                    var self = this;
+                Permalink.prototype.getParameters = function () {
                     var sidebarStatus = $location.search().sidebarStatus;
                     var sidebar = $location.search().sidebar;
+
                     return {
-                        zoom: self.zoom,
-                        center: [self.lon, self.lat],
-                        crs: self.urlCrs,
-                        layers: self.visibleLayerNames,
-                        defaultOverlays: self.visibleDefaultOverlays,
-                        backgroundLayer: self.backgroundLayer,
-                        catalogLayers: self.catalogLayerNames,
-                        visibleCatalogLayers: self.visibleCatalogLayerNames,
-                        catalogGroups: self.catalogGroupNames,
-                        visibleCatalogGroups: self.visibleCatalogGroupNames,
+                        zoom: this.zoom,
+                        center: [this.lon, this.lat],
+                        crs: this.urlCrs,
+                        layers: this.sortedLayerNames(),
+                        defaultOverlays: this.visibleDefaultOverlays.map(l => l.name),
+                        backgroundLayer: this.backgroundLayer.name,
+                        catalogLayers: this.catalogLayers.map(l => l.name),
+                        visibleCatalogLayers: this.visibleCatalogLayers.map(l => l.name),
+                        catalogGroups: this.catalogGroups.map(l => l.name),
+                        visibleCatalogGroups: this.visibleCatalogGroups.map(l => l.name),
                         sidebar: sidebar,
                         sidebarStatus: sidebarStatus
                     };
                 };
 
-                Permalink.prototype.getPermalinkParameters = function() {
-                    var self = this;
+                Permalink.prototype.getPermalinkParameters = function () {
                     return {
-                        zoom: self.zoom,
-                        center: [self.lon, self.lat],
-                        crs: self.urlCrs,
-                        layers: self.visibleLayerNames,
-                        defaultOverlays: self.visibleDefaultOverlays,
-                        backgroundLayer: self.backgroundLayer
+                        zoom: this.zoom,
+                        center: [this.lon, this.lat],
+                        crs: this.urlCrs,
+                        layers: this.sortedLayerNames(),
+                        defaultOverlays: this.defaultOverlays.map(l => l.name),
+                        backgroundLayer: this.backgroundLayer.name
                     };
                 };
 
-                Permalink.prototype.setPermalinkParameters = function(params) {
+                Permalink.prototype.setPermalinkParameters = function (params) {
                     var self = this;
                     self.deferred = $q.defer();
                     self.updateMapFromParameters(params);

--- a/src/modules/permalink/permalink-service.js
+++ b/src/modules/permalink/permalink-service.js
@@ -212,6 +212,7 @@ angular.module('anol.permalink')
                     }.bind(self));
 
                     setTimeout(() => {
+                        // bind listeners after initialization
                         for (const layer of permalinkLayers(LayersService.layers())) {
                             layer.onVisibleChange(self.handleVisibleChange, self);
                         }

--- a/src/modules/savesettings/savesettings-service.js
+++ b/src/modules/savesettings/savesettings-service.js
@@ -27,10 +27,10 @@ angular.module('anol.savesettings')
         };
         this.setDeleteUrl = function(deleteUrl) {
             _deleteUrl = deleteUrl;
-        };    
+        };
         this.setProjectName = function(projectName) {
             _projectName = projectName;
-        };    
+        };
         this.$get = ['$rootScope', '$window', '$q', '$http', '$timeout', '$translate', 'PermalinkService', 'PrintPageService', 'ProjectSettings', 'LayersService', 'CatalogService',
             function($rootScope, $window, $q, $http, $timeout, $translate, PermalinkService, PrintPageService, ProjectSettings, LayersService, CatalogService) {
                 /**
@@ -72,7 +72,7 @@ angular.module('anol.savesettings')
                     angular.forEach(ProjectSettings, function(value, idx) {
                         if (value.id == data.settings.id) {
                             index = idx;
-                        }   
+                        }
                     });
 
                     if (index > -1) {
@@ -86,10 +86,10 @@ angular.module('anol.savesettings')
                         LayersService.setLayerOrder(settings.layerswitcher.order);
                         LayersService.setCollapsedGroups(settings.layerswitcher.open);
                     })
-            
+
                     // save print settings and check if print tab is open
                     PrintPageService.loadSettings(settings);
-        
+
                     $rootScope.$broadcast('updateSidebar', settings);
                     // load control settings
                     $rootScope.pointMeasureResultSrs = settings.controls.measureSrs;
@@ -113,7 +113,7 @@ angular.module('anol.savesettings')
                     promise.then(function(response) {
                         if (ajax) {
                             self.applyLoadSettings(response.data.settings);
-                        } else {  
+                        } else {
                             $window.location.href = response.data.redirect;
                         }
                         deferred.resolve(response.data);
@@ -124,7 +124,7 @@ angular.module('anol.savesettings')
                             deferred.reject(response.data);
                         }
                     });
-            
+
                     return deferred.promise;
                 };
 
@@ -133,18 +133,18 @@ angular.module('anol.savesettings')
                     var deferred = $q.defer();
 
                     // save all map settings from permalink
-                    var permalinkData = PermalinkService.getSettings();
-                    // save all layer settings 
-                    var layers = LayersService.overLayersAsArray(); 
+                    var permalinkData = PermalinkService.getParameters();
+                    // save all layer settings
+                    var layers = LayersService.overLayersAsArray();
                     var deletedLayers = LayersService.deletedOverlayLayers;
 
-                    var groups = LayersService.getCollapsedGroups(); 
+                    var groups = LayersService.getCollapsedGroups();
                     // save print settings
                     var printData = PrintPageService.getSettings();
                     // save control settings
                     var controls = {
                         'measureSrs': $rootScope.pointMeasureResultSrs,
-                        'catalogVariant': CatalogService.getVariant(), 
+                        'catalogVariant': CatalogService.getVariant(),
                     };
                     var data = {
                         'projectName': self.projectName,
@@ -170,7 +170,7 @@ angular.module('anol.savesettings')
                             deferred.reject(response.data);
                         }
                     });
-            
+
                     return deferred.promise;
                 };
 
@@ -191,9 +191,9 @@ angular.module('anol.savesettings')
                             deferred.reject(response.data);
                         }
                     });
-            
+
                     return deferred.promise;
-                }; 
+                };
 
                 _saveManagerInstance = new SaveSettings(_saveUrl, _loadUrl, _deleteUrl, _projectName);
                 return _saveManagerInstance;


### PR DESCRIPTION
Because the handling of background layers and default overlays was not working correctly I dropped the special handling altogether and just handle all layers that have not set the property `permalink` to `false` the same.

Also I started to remember the whole layer objects instead of just their names. This makes it possible to sort them on generating links instead of keeping 2 collections.

Also removing of layers from the tree was not handled before. This results in a different approach in the `$watchCollection` function: Now only added or removed layers are handled.

Sorry for the large diff, I suggest turning whitespace differences off.