### PR TITLE
Use the same base logic in urlmarker-service and permalink-service.

### DIFF
--- a/src/modules/permalink/permalink-service.js
+++ b/src/modules/permalink/permalink-service.js
@@ -1,5 +1,6 @@
 import './module.js';
 import {transform, transformExtent} from 'ol/proj';
+import {getArrayParam, getObjectParam} from "../urlmarkers/util";
 
 angular.module('anol.permalink')
 
@@ -10,40 +11,6 @@ angular.module('anol.permalink')
     .provider('PermalinkService', [function () {
         var _urlCrs;
         var _precision = 100000;
-
-        /**
-         * @param {string} param
-         * @param {string[]} params
-         * @return {boolean|string}
-         */
-        var getParamString = function (param, params) {
-            if (angular.isUndefined(params[param])) {
-                return false;
-            }
-            var p = params[param];
-            if (angular.isArray(p)) {
-                p = p[p.length - 1];
-            }
-            return p;
-        };
-
-        const getArrayParam = function (param, params) {
-            const paramString = getParamString(param, params);
-            if (paramString !== false && paramString !== '') {
-                return paramString.split(',');
-            }
-        };
-
-        const getObjectParam = function (param, params) {
-            const paramString = getParamString(param, params);
-            if (paramString !== false && paramString !== '') {
-                const result = {};
-                for (const [key, value] of paramString.split('|').map(value => value.split(':'))) {
-                    result[key] = value;
-                }
-                return result;
-            }
-        };
 
         var extractMapParams = function (params) {
             var mapParams = getArrayParam('map', params);
@@ -455,7 +422,7 @@ angular.module('anol.permalink')
                             if ($rootScope.searchConfigsReady && $rootScope.layersReady) {
                                 const geocoder = GeocoderService.getGeocoder(config)
 
-                                geocodePromise = geocoder.request(term)
+                                geocodePromise = $q.resolve(geocoder.request(term))
                                     .then(results => {
                                         ReadyService.notifyAboutReady('geocoding');
                                         $rootScope.$broadcast('showSearchResult', results[0], false);

--- a/src/modules/urlmarkers/urlmarker-service.js
+++ b/src/modules/urlmarkers/urlmarker-service.js
@@ -1,14 +1,15 @@
 import './module.js';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
-import { fromExtent } from 'ol/geom/Polygon';
+import {fromExtent} from 'ol/geom/Polygon';
+import {getObjectParam, stringifyObject} from "./util";
 
 angular.module('anol.urlmarkers')
-/**
- * @ngdoc object
- * @name anol.urlmarkers.UrlMarkersServiceProvider
- */
-    .provider('UrlMarkersService', [function() {
+    /**
+     * @ngdoc object
+     * @name anol.urlmarkers.UrlMarkersServiceProvider
+     */
+    .provider('UrlMarkersService', [function () {
         var _defaultSrs;
         var _propertiesDelimiter = '|';
         var _keyValueDelimiter = ':';
@@ -17,177 +18,227 @@ angular.module('anol.urlmarkers')
         var _popupOffset = [0, 0];
 
         /**
-     * @ngdoc method
-     * @name setDefaultSrs
-     * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
-     * @param {string} srs default EPSG code of marker coordinates in url
-     */
-        this.setDefaultSrs = function(srs) {
+         * @ngdoc method
+         * @name setDefaultSrs
+         * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
+         * @param {string} srs default EPSG code of marker coordinates in url
+         */
+        this.setDefaultSrs = function (srs) {
             _defaultSrs = srs;
         };
 
         /**
-     * @ngdoc method
-     * @name setPropertiesDelimiter
-     * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
-     * @param {string} delimiter Delimiter separating marker properties
-     */
-        this.setPropertiesDelimiter = function(delimiter) {
+         * @ngdoc method
+         * @name setPropertiesDelimiter
+         * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
+         * @param {string} delimiter Delimiter separating marker properties
+         */
+        this.setPropertiesDelimiter = function (delimiter) {
             _propertiesDelimiter = delimiter || _propertiesDelimiter;
         };
 
         /**
-     * @ngdoc method
-     * @name setKeyValueDelimiter
-     * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
-     * @param {string} delimiter Delimiter separating properties keys from values
-     */
-        this.setKeyValueDelimiter = function(delimiter) {
+         * @ngdoc method
+         * @name setKeyValueDelimiter
+         * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
+         * @param {string} delimiter Delimiter separating properties keys from values
+         */
+        this.setKeyValueDelimiter = function (delimiter) {
             _keyValueDelimiter = delimiter || _keyValueDelimiter;
         };
 
         /**
-     * @ngdoc method
-     * @name setMarkerStyle
-     * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
-     * @param {object} style marker style
-     */
-        this.setMarkerStyle = function(style) {
+         * @ngdoc method
+         * @name setMarkerStyle
+         * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
+         * @param {object} style marker style
+         */
+        this.setMarkerStyle = function (style) {
             _style = style;
         };
 
         /**
-     * @ngdoc method
-     * @name setPopup
-     * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
-     * @param {boolean} usePopup
-     * @description When not using popup a label text is added. This can be styled by markerStyle
-     */
-        this.setUsePopup = function(usePopup) {
+         * @ngdoc method
+         * @name setPopup
+         * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
+         * @param {boolean} usePopup
+         * @description When not using popup a label text is added. This can be styled by markerStyle
+         */
+        this.setUsePopup = function (usePopup) {
             _usePopup = angular.isUndefined(usePopup) ? _usePopup : usePopup;
         };
 
         /**
-     * @ngdoc method
-     * @name setPopupOffset
-     * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
-     * @param {Array.<number>} popupOffset Offset of placed popup. First value is x- second value is y-offset in px
-     */
-        this.setPopupOffset = function(popupOffset) {
+         * @ngdoc method
+         * @name setPopupOffset
+         * @methodOf anol.urlmarkers.UrlMarkersServiceProvider
+         * @param {Array.<number>} popupOffset Offset of placed popup. First value is x- second value is y-offset in px
+         */
+        this.setPopupOffset = function (popupOffset) {
             _popupOffset = angular.isUndefined(popupOffset) ? _popupOffset : popupOffset;
         };
 
-        this.$get = ['$location', 'MapService', 'LayersService', function($location, MapService, LayersService) {
-        /**
-         * @ngdoc service
-         * @name anol.urlmarkers.UrlMarkersService
-         *
-         * @description
-         * Adds markers specified in url. A valid url marker looks like marker=color:ff0000|label:foobar|coord:8.21,53.15|srs:4326
-         */
-            var UrlMarkers = function(defaultSrs, propertiesDelimiter, keyValueDelimiter, style, usePopup, popupOffset) {
-                var self = this;
-                self.features = [];
-                self.defaultSrs = defaultSrs || MapService.view.getProjection();
-                self.propertiesDelimiter = propertiesDelimiter;
-                self.keyValueDelimiter = keyValueDelimiter;
-                self.style = style;
-                self.usePopup = usePopup;
-                self.popupOffset = popupOffset;
-                self.extractFeaturesFromUrl();
+        this.$get = ['$location', 'MapService', 'LayersService', function ($location, MapService, LayersService) {
+            /**
+             * @ngdoc service
+             * @name anol.urlmarkers.UrlMarkersService
+             *
+             * @description
+             * Adds markers specified in url. A valid url marker looks like marker=color:ff0000|label:foobar|coord:8.21,53.15|srs:4326
+             */
+            class UrlMarkerService {
+                constructor(defaultSrs, propertiesDelimiter, keyValueDelimiter, style, usePopup, popupOffset) {
+                    var self = this;
+                    self.defaultSrs = defaultSrs || MapService.view.getProjection();
+                    self.propertiesDelimiter = propertiesDelimiter;
+                    self.keyValueDelimiter = keyValueDelimiter;
+                    self.style = style;
+                    self.usePopup = usePopup;
+                    self.popupOffset = popupOffset;
 
-                if(self.features.length === 0) {
-                    return;
+                    self.layer = self.createLayer();
+
+                    self.extractFeaturesFromUrl();
+
+                    LayersService.addSystemLayer(self.layer);
                 }
 
-                self.layer = self.createLayer(self.features);
-
-                LayersService.addSystemLayer(self.layer);
-            };
-
-            UrlMarkers.prototype.extractFeaturesFromUrl = function() {
-                var self = this;
-                var urlParams = $location.search();
-                if(angular.isUndefined(urlParams.marker)) {
-                    return false;
-                }
-
-                var markers = angular.isArray(urlParams.marker) ? urlParams.marker : [urlParams.marker];
-                angular.forEach(markers, function(_marker) {
-                    var params = _marker.split(self.propertiesDelimiter);
-                    if(params.length === 0) {
-                        return;
+                extractFeaturesFromUrl() {
+                    var self = this;
+                    var urlParams = $location.search();
+                    if (angular.isUndefined(urlParams.marker)) {
+                        return false;
                     }
 
-                    var marker = {};
-                    var style = {};
-                    var shouldFit = false;
+                    const markers = getObjectParam('marker', urlParams, true);
 
-                    angular.forEach(params, function(kv) {
-                        kv = kv.split(self.keyValueDelimiter);
-                        if(kv[0] === 'coord') {
-                            var coord = kv[1].split(',');
-                            coord = [parseFloat(coord[0]), parseFloat(coord[1])];
-                            marker.geometry = new Point(coord);
-                        } else if (kv[0] === 'bbox') {
-                            var extent = kv[1].split(',').map(parseFloat);
-                            marker.geometry = fromExtent(extent);
-                        } else if (kv[0] === 'srs') {
-                            marker.srs = 'EPSG:' + kv[1];
-                        } else if (kv[0] === 'color') {
-                            style = {
-                                fillColor: '#' + kv[1],
-                                strokeColor: '#' + kv[1],
-                                graphicColor: '#' + kv[1]
-                            };
-                        } else if (kv[0] === 'fit') {
-                            shouldFit = JSON.parse(kv[1]);
+                    for (const marker of markers) {
+                        let geometry;
+                        let isBbox;
+                        if (marker.coord) {
+                            const coords = marker.coord.split(',').map(parseFloat);
+                            geometry = new Point(coords);
+                            isBbox = false;
+                        } else if (marker.bbox) {
+                            const extent = marker.bbox.split(',').map(parseFloat);
+                            geometry = fromExtent(extent);
+                            isBbox = true;
                         } else {
-                            marker[kv[0]] = kv[1];
+                            console.error('Url Marker is missing geometry (bbox or coord)');
+                            continue;
                         }
-                    });
-                    if(angular.isUndefined(marker.geometry)) {
-                        return;
-                    }
-                    marker.geometry.transform(
-                        marker.srs || self.defaultSrs,
-                        MapService.view.getProjection().getCode()
-                    );
-                    marker.style = angular.merge({}, self.style, style);
-                    if(!self.usePopup && angular.isDefined(marker.label)) {
-                        marker.style.text = marker.label;
-                    }
-                    self.features.push(new Feature(marker));
-                    if (shouldFit) {
-                        var map = MapService.getMap();
-                        map.once('postrender', function () {
-                            map.getView().fit(marker.geometry);
-                            const newParams = params.filter(kv => !kv.startsWith('fit'));
-                            $location.search('marker', newParams.join(self.propertiesDelimiter));
-                            $location.replace();
+
+                        let srs = self.defaultSrs;
+
+                        if (marker.srs) {
+                            srs = `EPSG:${marker.srs}`;
+                        }
+
+                        geometry = geometry.transform(
+                            srs,
+                            MapService.getMap().getView().getProjection().getCode()
+                        );
+
+                        self.createMarker({
+                            geometry,
+                            color: marker.color,
+                            label: marker.label,
+                            srs: marker.srs,
+                            isBbox,
+                            fit: marker.fit
                         });
                     }
-                });
-            };
 
-            UrlMarkers.prototype.createLayer = function(features) {
-                var layer = new anol.layer.Feature({
-                    name: 'markersLayer',
-                    olLayer: {
-                        zIndex: 2001,
-                        source: {
-                            features: features
+                    this.updateUrl();
+                }
+
+                updateUrl() {
+                    const mapProjection = MapService.getMap().getView().getProjection().getCode();
+                    const markers = this.layer.olLayer.getSource().getFeatures().map(f => {
+                        const params = {};
+
+                        let srs = this.defaultSrs;
+                        if (angular.isDefined(f.get('srs'))) {
+                            srs = `EPSG:${f.get('srs')}`;
+                            params.srs = f.get('srs');
                         }
+
+                        const geometry = f.getGeometry().transform(
+                            mapProjection,
+                            srs
+                        );
+
+                        if (f.get('isBbox')) {
+                            params.bbox = geometry.getExtent().join(',')
+                        } else {
+                            params.coord = geometry.getFirstCoordinate().join(',')
+                        }
+                        if (angular.isDefined(f.get('label'))) {
+                            params.label = f.get('label');
+                        }
+                        if (angular.isDefined(f.get('color'))) {
+                            params.label = f.get('color');
+                        }
+                        return stringifyObject(params);
+                    });
+
+                    const search = angular.copy($location.search())
+                    search.marker = markers;
+
+                    $location.search(search);
+                    $location.replace();
+                }
+
+                createMarker({geometry, color, label, fit, isBbox}) {
+                    let style = {};
+                    if (angular.isDefined(color)) {
+                        style = {
+                            fillColor: '#' + color,
+                            strokeColor: '#' + color,
+                            graphicColor: '#' + color
+                        };
                     }
-                });
 
-                var olLayerOptions = layer.olLayerOptions;
-                olLayerOptions.source = new layer.OL_SOURCE_CLASS(layer.olSourceOptions);
-                layer.setOlLayer(new layer.OL_LAYER_CLASS(olLayerOptions));
+                    const options = {
+                        geometry,
+                        label,
+                        color,
+                        isBbox,
+                        style: angular.merge({}, this.style, style)
+                    };
 
-                return layer;
-            };
+                    if (!this.usePopup && angular.isDefined(label)) {
+                        options.style.text = label;
+                    }
+                    this.layer.olLayer.getSource().addFeature(new Feature(options));
+                    if (fit) {
+                        const map = MapService.getMap();
+                        map.once('postrender', () => {
+                            map.getView().fit(geometry);
+                            this.updateUrl();
+                        });
+                    }
+                }
 
-            return new UrlMarkers(_defaultSrs, _propertiesDelimiter, _keyValueDelimiter, _style, _usePopup, _popupOffset);
+                createLayer() {
+                    var layer = new anol.layer.Feature({
+                        name: 'markersLayer',
+                        olLayer: {
+                            zIndex: 2001,
+                            source: {
+                                features: []
+                            }
+                        }
+                    });
+
+                    var olLayerOptions = layer.olLayerOptions;
+                    olLayerOptions.source = new layer.OL_SOURCE_CLASS(layer.olSourceOptions);
+                    layer.setOlLayer(new layer.OL_LAYER_CLASS(olLayerOptions));
+
+                    return layer;
+                }
+            }
+
+            return new UrlMarkerService(_defaultSrs, _propertiesDelimiter, _keyValueDelimiter, _style, _usePopup, _popupOffset);
         }];
     }]);

--- a/src/modules/urlmarkers/util.js
+++ b/src/modules/urlmarkers/util.js
@@ -1,0 +1,50 @@
+/**
+ * @param {string} param
+ * @param {Object<string[]|string>} params
+ * @param {boolean} multi
+ * @return {string|string[]}
+ */
+function getParamString(param, params, multi = false) {
+    if (angular.isUndefined(params[param])) {
+        return '';
+    }
+    var p = params[param];
+    if (angular.isArray(p) && !multi) {
+        return p[p.length - 1];
+    } else if (multi && !angular.isArray(p)) {
+        return [p];
+    } else {
+        return p;
+    }
+}
+
+export function getArrayParam(param, params) {
+    const paramString = getParamString(param, params);
+    if (paramString !== false && paramString !== '') {
+        return paramString.split(',');
+    }
+}
+
+function parseObject(paramString) {
+    if (paramString !== false && paramString !== '') {
+        const result = {};
+        for (const [key, value] of paramString.split('|').map(value => value.split(':'))) {
+            result[key] = value;
+        }
+        return result;
+    }
+}
+
+export function getObjectParam(param, params, multi = false) {
+    if (!multi) {
+        return parseObject(getParamString(param, params, multi));
+    } else {
+        return getParamString(param, params, multi).map(parseObject);
+    }
+}
+
+export function stringifyObject(object) {
+    return Object.keys(object)
+        .map(k => `${k}:${encodeURIComponent(object[k])}`)
+        .join('|');
+}


### PR DESCRIPTION
Move helper functions for url parameters into a `util.js` and use them in urlmarker-service and permalink-service.

Refactor some functionality in urlmarker-service into function `createMarker` to be able to call that from outside.