### PR TITLE
insert undefined check in layer filter function

### DIFF
--- a/src/modules/print/print-directive.js
+++ b/src/modules/print/print-directive.js
@@ -84,7 +84,7 @@ angular.module('anol.print')
 
                             var layers = [LayersService.activeBackgroundLayer()];
                             layers = layers.concat(prepareOverlays(LayersService.overlayLayers)).filter(function(l) {
-                                return l.name !== undefined;
+                                return l !== undefined && l.name !== undefined;
                             });
 
                             layers.push(DrawService.activeLayer);


### PR DESCRIPTION
because of the showNoBackground function, the background layer can be undefined, so we need a check for this in the filter function.