### PR TITLE
allow combining catalog layers

### DIFF
--- a/src/anol/layer/basewms.js
+++ b/src/anol/layer/basewms.js
@@ -50,7 +50,6 @@ class BaseWMS extends AnolBaseLayer {
             !this.isBackground &&
             angular.equals(ownParams, otherParams) &&
             angular.equals(this.anolGroup, other.anolGroup) &&
-            !this.catalog &&
             angular.isUndefined(this.options.opacity) && angular.isUndefined(other.options.opacity);
     }
 


### PR DESCRIPTION
This enables combining catalog layers in groups into a single wms to reduce the number of http requests in the browser.

- Visiblity of single layers can still be en-/disabled specifically.
- Layer ordering still works (if supported by providing WMS)
