### PR TITLE
Update layer visibility from settings with already existing layer

### DIFF
--- a/src/modules/catalog/catalog-service.js
+++ b/src/modules/catalog/catalog-service.js
@@ -410,8 +410,11 @@ angular.module('anol.catalog')
             if(self.addedLayersName.indexOf(layerName) !== -1 ) {
                 return;
             }
-            var exist = LayersService.layerByName(layerName);
-            if (exist) {
+            var alreadyAddedLayer = LayersService.layerByName(layerName);
+            if (alreadyAddedLayer) {
+                // Even if the layer was already added,
+                // we want to update the visibility of that layer.
+                alreadyAddedLayer.setVisible(visible);
                 return;
             }
 


### PR DESCRIPTION
This fixes setting the visibility of layers when loading settings. Visibility was not updated for catalog layers that are both part of the actual app config, and the settings config.