### PR TITLE
trigger digest after async calls

### DIFF
--- a/src/modules/permalink/permalink-service.js
+++ b/src/modules/permalink/permalink-service.js
@@ -375,6 +375,7 @@ angular.module('anol.permalink')
 
                         $rootScope.$watch('sidebar.open', () => self.generatePermalink());
                         $rootScope.$watch('sidebar.openItems', () => self.generatePermalink());
+                        $rootScope.$digest();
                     }
 
                     /**


### PR DESCRIPTION
this (hopefully) fixes the layer ordering, by explictly triggering the digest after all async operations are done