### PR TITLE
fix: setting style for cluster layer

### DIFF
--- a/src/anol/layer/feature.js
+++ b/src/anol/layer/feature.js
@@ -161,7 +161,7 @@ class FeatureLayer extends AnolBaseLayer {
         }
 
         olLayer.setStyle(function(feature, resolution) {
-            if (angular.isDefined(feature) && feature.get('_digitizeState') === DigitizeState.REMOVED) {
+            if (feature && feature.get('_digitizeState') === DigitizeState.REMOVED) {
                 return null;
             }
             var style = self.createStyle(feature, resolution);

--- a/src/anol/layer/feature.js
+++ b/src/anol/layer/feature.js
@@ -161,7 +161,7 @@ class FeatureLayer extends AnolBaseLayer {
         }
 
         olLayer.setStyle(function(feature, resolution) {
-            if (feature.get('_digitizeState') === DigitizeState.REMOVED) {
+            if (angular.isDefined(feature) && feature.get('_digitizeState') === DigitizeState.REMOVED) {
                 return null;
             }
             var style = self.createStyle(feature, resolution);


### PR DESCRIPTION
This fixes the styling of cluster layers by adding a null pointer check for `feature` in the style function.