### PR TITLE
feat: send broadcast signal when layer was refreshed

### DIFF
--- a/src/modules/savemanager/savemanager-service.js
+++ b/src/modules/savemanager/savemanager-service.js
@@ -533,6 +533,10 @@ angular.module('anol.savemanager')
                         // we only want to watch until loaded is true once
                         unregister();
                         self.refreshLayerByPollingResult(layer, addedFeatures, changedFeatures, removedFeatures);
+                        $rootScope.$broadcast('SaveManagerService:refreshLayer', {
+                            success: true,
+                            layerName: layerName
+                        });
                     }
                 });
                 layer.refresh();


### PR DESCRIPTION
This adds a broadcast when layer was refreshed. This is needed for the refresh button to disappear directly after refreshing the layer instead of disappearing after next polling.