### PR TITLE
fix: make singleSelect work for layer groups

### DIFF
--- a/src/anol/layer.js
+++ b/src/anol/layer.js
@@ -147,10 +147,13 @@ class AnolBaseLayer {
         return this.olLayer.getVisible();
     }
     setVisible(visible)  {
+        const self = this;
         if (visible && this.hasGroup()) {
             if (this.anolGroup.singleSelect) {
                 $.each(this.anolGroup.layers, function(idx, layer) {
-                    if (layer.getVisible()) {
+                    // Only set other layers invisible, not the one we want to have visible.
+                    // Otherwise the WMS param for that layer will be removed.
+                    if (layer.getVisible() && layer !== self) {
                         layer.setVisible(false); // layer.setVisible will update WMS params
                     }
                 });

--- a/src/anol/layer/basewms.js
+++ b/src/anol/layer/basewms.js
@@ -124,7 +124,7 @@ class BaseWMS extends AnolBaseLayer {
         params.LAYERS = visibleWmsLayers.toReversed().join(',');
         source.updateParams(params);
         this.visible = visible;
-        super.setVisible(visibleWmsLayers.length > 0);
+        super.setVisible(visible);
     }
     getLegendGraphicUrl() {
         var requestParams = {


### PR DESCRIPTION
This fixes singleSelect for layer groups. Before, layer.PARAMS was cleared by (re-)setting the visibility of all layers in a singleSelect group. Now we skip resetting the layer that is being set visible.