### PR TITLE
Layer order

### DIFF
--- a/src/anol/helper.js
+++ b/src/anol/helper.js
@@ -46,7 +46,7 @@ const helper = {
         return r;
     },
     /**
-     * Inserts content of array by into array a starting at position at.
+     * Inserts content of array b into array a starting at position at.
      * When at is undefined, append b to a
      */
     concat(a, b, at) {

--- a/src/anol/layer.js
+++ b/src/anol/layer.js
@@ -159,7 +159,13 @@ class AnolBaseLayer {
                 });
             }
         }
-        this.olLayer.setVisible(visible);
+        // For combined layers, visibility depends on at least
+        // one other layer in combination being visible.
+        let olLayerVisible = visible;
+        if (this.combined) {
+            olLayerVisible = this.anolGroup.layers.some(l => l.getVisible());
+        }
+        this.olLayer.setVisible(olLayerVisible);
         angular.element(this).triggerHandler('anol.layer.visible:change', [this]);
     }
     onVisibleChange(func, context) {

--- a/src/anol/layer/basewms.js
+++ b/src/anol/layer/basewms.js
@@ -108,9 +108,18 @@ class BaseWMS extends AnolBaseLayer {
             return;
         }
 
-        const insertLayerIdx = this.olLayer.get('anolLayers')
-            .filter(l => l !== this && l.getVisible())
-            .reduce((prev, next) => prev + next.wmsSourceLayers.length, 0);
+        // We have to place the activated layer at the
+        // position in the params.LAYERS string, according
+        // to the layer's position in the group.
+        const anolLayers = this.olLayer.get('anolLayers');
+        const selfIdx = anolLayers.indexOf(this);
+        let insertLayerIdx = 0;
+        for (let i = 0; i < selfIdx; i++) {
+            const l = anolLayers[i];
+            if (l.getVisible()) {
+                insertLayerIdx += l.wmsSourceLayers.length;
+            }
+        }
 
         const source = this.olLayer.getSource();
         const params = source.getParams();


### PR DESCRIPTION
This
- preserves the layer order when activating and deactivating combinable layers
- fixes setting the visibility for combinable layers with and without singleSelect activated