### PR TITLE
Fix comparison between ids

### DIFF
--- a/src/modules/savesettings/savesettings-directive.js
+++ b/src/modules/savesettings/savesettings-directive.js
@@ -53,7 +53,7 @@ angular.module('anol.savesettings')
                         // load project name to overwrite
                         if (angular.isUndefined(name) || scope.id) {
                             angular.forEach(scope.projectSettings, function (value) {
-                                if (value.id === scope.id) {
+                                if (value.id === parseInt(scope.id)) {
                                     name = value.name;
                                 }
                             });

--- a/src/modules/savesettings/savesettings-directive.js
+++ b/src/modules/savesettings/savesettings-directive.js
@@ -53,7 +53,7 @@ angular.module('anol.savesettings')
                         // load project name to overwrite
                         if (angular.isUndefined(name) || scope.id) {
                             angular.forEach(scope.projectSettings, function (value) {
-                                if (value.id === parseInt(scope.id)) {
+                                if (value.id === parseInt(scope.id, 10)) {
                                     name = value.name;
                                 }
                             });


### PR DESCRIPTION
This PR parses the `scope.id` to an integer in order to compare it to `projectSettings.id` which is an integer.

Please review