### PR TITLE
fix: add separator to feature-properties

### DIFF
--- a/src/modules/featureproperties/templates/featureproperties.html
+++ b/src/modules/featureproperties/templates/featureproperties.html
@@ -1,5 +1,6 @@
 <div class="anol-feature-properties-wrapper" ng-style="style">
     <div ng-if="propertiesCollection.length > 0" ng-repeat="properties in propertiesCollection">
+        <hr ng-if="!$first" />
         <table class="anol-feature-properties-table">
             <tr ng-repeat="(key, value) in properties">
                 <td class="anol-feature-properties-table-key-col">{{ value.key }}:</td>


### PR DESCRIPTION
Adds a visual separator between different items in feature-properties

<img width="515" height="384" alt="image" src="https://github.com/user-attachments/assets/bbdfe4b8-353a-49aa-b3d8-d064a773df5f" />
