### PR TITLE
fix: handle visibility change of top-level combined layers

### DIFF
--- a/src/anol/layer.js
+++ b/src/anol/layer.js
@@ -162,7 +162,9 @@ class AnolBaseLayer {
         // For combined layers, visibility depends on at least
         // one other layer in combination being visible.
         let olLayerVisible = visible;
-        if (this.combined) {
+        // Top-level layers might be combined while not being
+        // in a group.
+        if (this.combined && this.hasGroup()) {
             olLayerVisible = this.anolGroup.layers.some(l => l.getVisible());
         }
         this.olLayer.setVisible(olLayerVisible);


### PR DESCRIPTION
This fixes setting the visibility of combined layers at top level. These layers are combined, but are not part of a common group