### PR TITLE
Refactor: require -> import

### DIFF
--- a/examples/attributions.js
+++ b/examples/attributions.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 import Point from 'ol/geom/Point';

--- a/examples/change_language.js
+++ b/examples/change_language.js
@@ -1,5 +1,5 @@
-require('angular');
-require('angular-translate');
+import 'angular';
+import 'angular-translate';
 
 import View from 'ol/View';
 import GeoJSON from 'ol/format/GeoJSON.js'

--- a/examples/clustering.js
+++ b/examples/clustering.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 import Point from 'ol/geom/Point';

--- a/examples/draw.js
+++ b/examples/draw.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 

--- a/examples/featurepopup.js
+++ b/examples/featurepopup.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 import Polygon from 'ol/geom/Polygon';

--- a/examples/featureproperties.js
+++ b/examples/featureproperties.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 import Point from 'ol/geom/Point';

--- a/examples/featurepropertieseditor.js
+++ b/examples/featurepropertieseditor.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 import GeoJSON from 'ol/format/GeoJSON.js'

--- a/examples/featurestyleeditor.js
+++ b/examples/featurestyleeditor.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 import GeoJSON from 'ol/format/GeoJSON.js'

--- a/examples/geocoder.js
+++ b/examples/geocoder.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 import View from 'ol/View';
 
 angular.module('example', ['anol', 'anol.map', 'anol.featurepopup', 'anol.zoom', 'anol.geocoder', 'anol.urlmarkers'])

--- a/examples/geolocate.js
+++ b/examples/geolocate.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 

--- a/examples/labeling.js
+++ b/examples/labeling.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 import Point from 'ol/geom/Point';

--- a/examples/layerswitcher.js
+++ b/examples/layerswitcher.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 import Feature from 'ol/Feature';

--- a/examples/legend.js
+++ b/examples/legend.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 import Point from 'ol/geom/Point';

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 import Style from 'ol/style/Style';

--- a/examples/mouseposition.js
+++ b/examples/mouseposition.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 

--- a/examples/overviewmap.js
+++ b/examples/overviewmap.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 

--- a/examples/permalink.js
+++ b/examples/permalink.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 import Point from 'ol/geom/Point';

--- a/examples/simplemap.js
+++ b/examples/simplemap.js
@@ -1,4 +1,4 @@
-require('angular');
+import 'angular';
 
 import View from 'ol/View';
 

--- a/src/modules/geolocation/geolocation-directive.js
+++ b/src/modules/geolocation/geolocation-directive.js
@@ -157,11 +157,12 @@ angular.module('anol.geolocation')
                         if (scope.showPosition) {
                             addGeolocationFeatures(accuracyGeometry, position);
                         }
-                        view.setCenter(position);
-                        view.fit(accuracyGeometry.getExtent(), MapService.getMap().getSize());
-                        if (angular.isDefined(scope.zoom) && parseInt(scope.zoom) < view.getZoom()) {
-                            view.setZoom(parseInt(scope.zoom));
-                        }
+                        view.fit(accuracyGeometry.getExtent(), {
+                            size: MapService.getMap().getSize(),
+                            padding: [10, 10, 10, 10],
+                            duration: 500,
+                            maxZoom: (angular.isDefined(scope.zoom) && parseInt(scope.zoom) < view.getZoom()) ? parseInt(scope.zoom) : undefined
+                        });
                     });
 
                     scope.locate = function () {


### PR DESCRIPTION
The `/examples/*.js` files still had `require` statements. 
I converted them to `import`s.
Perhaps this change is irrelevant, because the modified files are not used for build?