### PR TITLE
feat: replace absolute-positioned controls with CSS flex column

### DIFF
--- a/src/modules/map/controls-service.js
+++ b/src/modules/map/controls-service.js
@@ -22,7 +22,7 @@ angular.module('anol.map')
             _controls = controls;
         };
 
-        this.$get = ['ClusterSelectService', function(ClusterSelectService) {
+        this.$get = ['ClusterSelectService', '$rootScope', function(ClusterSelectService, $rootScope) {
         /**
          * @ngdoc service
          * @name anol.map.ControlsService
@@ -32,6 +32,7 @@ angular.module('anol.map')
          */
             var Controls = function(controls) {
                 var self = this;
+                self.$rootScope = $rootScope;
                 self.olControls = [];
                 self.controls = [];
                 self.menus = [];
@@ -75,6 +76,7 @@ angular.module('anol.map')
                 angular.forEach(self.olControls, function(control) {
                     self.map.addControl(control);
                 });
+                self.$rootScope.$broadcast('anol.controls.registered');
             };
             /**
          * @ngdoc method


### PR DESCRIPTION
Most changes are in the [corresponding bielefeldGEOCLIENT branch](https://github.com/stadt-bielefeld/bielefeldGEOCLIENT/pull/418). 

The only change here is broadcasting a `anol.controls.registered` event as soon as all controls have been added to the map, [for them to be moved](https://github.com/stadt-bielefeld/bielefeldGEOCLIENT/pull/418/changes/57a4465dd2c6878ac37895fbc024a9e58235b2bc) into the wrapper `<div>`.